### PR TITLE
Add support for id_type parameter in Add / Remove people from segment

### DIFF
--- a/segments_customerio.go
+++ b/segments_customerio.go
@@ -5,8 +5,24 @@ import (
 	"fmt"
 )
 
+// IDType is the type of ids you want to use.
+// All the values in the ids array must be of this type.
+// If you don't provide this parameter, we assume that the ids array contains id values.
+// Enum values:
+//   - "id"
+//   - "email"
+//   - "cio_id"
+type IDType string
+
+const (
+	IDTypeID      IDType = "id"
+	IDTypeEmail   IDType = "email"
+	IDTypeCioID   IDType = "cio_id"
+	DefaultIDType        = IDTypeID
+)
+
 // AddPeopleToSegment adds people to a segment.
-func (c *CustomerIO) AddPeopleToSegment(ctx context.Context, segmentID int, ids []string) error {
+func (c *CustomerIO) AddPeopleToSegment(ctx context.Context, segmentID int, idType string, ids []string) error {
 	if segmentID == 0 {
 		return ParamError{Param: "segmentID"}
 	}
@@ -14,14 +30,14 @@ func (c *CustomerIO) AddPeopleToSegment(ctx context.Context, segmentID int, ids 
 		return ParamError{Param: "ids"}
 	}
 	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/segments/%d/add_customers", c.URL, segmentID),
+		fmt.Sprintf("%s/api/v1/segments/%d/add_customers?id_type=%s", c.URL, segmentID, c.getValidIDType(idType)),
 		map[string]interface{}{
 			"ids": ids,
 		})
 }
 
 // RemovePeopleFromSegment removes people from a segment
-func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int, ids []string) error {
+func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int, idType string, ids []string) error {
 	if segmentID == 0 {
 		return ParamError{Param: "segmentID"}
 	}
@@ -29,8 +45,18 @@ func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int,
 		return ParamError{Param: "ids"}
 	}
 	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/segments/%d/remove_customers", c.URL, segmentID),
+		fmt.Sprintf("%s/api/v1/segments/%d/remove_customers?id_type=%s", c.URL, segmentID, c.getValidIDType(idType)),
 		map[string]interface{}{
 			"ids": ids,
 		})
+}
+
+// getValidIDType returns the valid IDType or defaults to IDTypeID
+func (c *CustomerIO) getValidIDType(idType string) IDType {
+	switch IDType(idType) {
+	case IDTypeEmail, IDTypeCioID:
+		return IDType(idType)
+	default:
+		return DefaultIDType
+	}
 }

--- a/segments_customerio_test.go
+++ b/segments_customerio_test.go
@@ -2,7 +2,6 @@ package customerio_test
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,12 +11,53 @@ import (
 
 func TestAddPeopleToSegment(t *testing.T) {
 	customerIDs := []string{"1", "2", "3"}
-	var verify = func(request []byte) {}
+	var verify = func(req *http.Request) {
+		idType := req.URL.Query().Get("id_type")
+		if idType != "id" {
+			t.Errorf("Expected id_type to be 'id', got '%s'", idType)
+		}
+	}
 
 	api, srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), testSegmentID, customerIDs)
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, "id", customerIDs)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAddPeopleToSegmentEmailIDType(t *testing.T) {
+	customerIDs := []string{"1", "2", "3"}
+	var verify = func(req *http.Request) {
+		idType := req.URL.Query().Get("id_type")
+		if idType != "email" {
+			t.Errorf("Expected id_type to be 'email', got '%s'", idType)
+		}
+	}
+
+	api, srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, "email", customerIDs)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAddPeopleToSegmentCioIDType(t *testing.T) {
+	customerIDs := []string{"1", "2", "3"}
+	var verify = func(req *http.Request) {
+		idType := req.URL.Query().Get("id_type")
+		if idType != "cio_id" {
+			t.Errorf("Expected id_type to be 'cio_id', got '%s'", idType)
+		}
+	}
+
+	api, srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, "cio_id", customerIDs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -25,12 +65,12 @@ func TestAddPeopleToSegment(t *testing.T) {
 
 func TestAddPeopleToSegmentSegmentParamError(t *testing.T) {
 	var customerIDs []string
-	var verify = func(request []byte) {}
+	var verify = func(req *http.Request) {}
 
 	api, srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), 0, customerIDs)
+	err := api.AddPeopleToSegment(context.Background(), 0, "id", customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -42,12 +82,12 @@ func TestAddPeopleToSegmentSegmentParamError(t *testing.T) {
 
 func TestAddPeopleToSegmentIDsParamError(t *testing.T) {
 	var customerIDs []string
-	var verify = func(request []byte) {}
+	var verify = func(req *http.Request) {}
 
 	api, srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), testSegmentID, customerIDs)
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, "id", customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -59,12 +99,12 @@ func TestAddPeopleToSegmentIDsParamError(t *testing.T) {
 
 func TestAddPeopleToSegmentError(t *testing.T) {
 	customerIDs := []string{"1", "2", "3"}
-	var verify = func(request []byte) {}
+	var verify = func(req *http.Request) {}
 
 	api, srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), notFoundID, customerIDs)
+	err := api.AddPeopleToSegment(context.Background(), notFoundID, "id", customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -74,15 +114,9 @@ func TestAddPeopleToSegmentError(t *testing.T) {
 	}
 }
 
-func segmentsTrackServer(t *testing.T, verify func(request []byte)) (*customerio.CustomerIO, *httptest.Server) {
+func segmentsTrackServer(t *testing.T, verify func(req *http.Request)) (*customerio.CustomerIO, *httptest.Server) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		b, err := ioutil.ReadAll(req.Body)
-		if err != nil {
-			t.Error(err)
-		}
-		defer req.Body.Close()
-
-		verify(b)
+		verify(req)
 
 		switch true {
 		case req.Method == "POST" && req.URL.Path == "/api/v1/segments/1/add_customers":
@@ -106,12 +140,53 @@ func segmentsTrackServer(t *testing.T, verify func(request []byte)) (*customerio
 
 func TestRemovePeopleFromSegment(t *testing.T) {
 	customerIDs := []string{"1", "2", "3"}
-	var verify = func(request []byte) {}
+	var verify = func(req *http.Request) {
+		idType := req.URL.Query().Get("id_type")
+		if idType != "id" {
+			t.Errorf("Expected id_type to be 'id', got '%s'", idType)
+		}
+	}
 
 	api, srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, customerIDs)
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, "id", customerIDs)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestRemovePeopleToSegmentEmailIDType(t *testing.T) {
+	customerIDs := []string{"1", "2", "3"}
+	var verify = func(req *http.Request) {
+		idType := req.URL.Query().Get("id_type")
+		if idType != "email" {
+			t.Errorf("Expected id_type to be 'email', got '%s'", idType)
+		}
+	}
+
+	api, srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, "email", customerIDs)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestRemovePeopleToSegmentCioIDType(t *testing.T) {
+	customerIDs := []string{"1", "2", "3"}
+	var verify = func(req *http.Request) {
+		idType := req.URL.Query().Get("id_type")
+		if idType != "cio_id" {
+			t.Errorf("Expected id_type to be 'cio_id', got '%s'", idType)
+		}
+	}
+
+	api, srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, "cio_id", customerIDs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -119,12 +194,12 @@ func TestRemovePeopleFromSegment(t *testing.T) {
 
 func TestRemovePeopleFromSegmentSegmentParamError(t *testing.T) {
 	var customerIDs []string
-	var verify = func(request []byte) {}
+	var verify = func(req *http.Request) {}
 
 	api, srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), 0, customerIDs)
+	err := api.RemovePeopleFromSegment(context.Background(), 0, "id", customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -136,12 +211,12 @@ func TestRemovePeopleFromSegmentSegmentParamError(t *testing.T) {
 
 func TestRemovePeopleFromSegmentIDsParamError(t *testing.T) {
 	var customerIDs []string
-	var verify = func(request []byte) {}
+	var verify = func(req *http.Request) {}
 
 	api, srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, customerIDs)
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, "id", customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -153,12 +228,12 @@ func TestRemovePeopleFromSegmentIDsParamError(t *testing.T) {
 
 func TestRemovePeopleFromSegmentError(t *testing.T) {
 	customerIDs := []string{"1", "2", "3"}
-	var verify = func(request []byte) {}
+	var verify = func(req *http.Request) {}
 
 	api, srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), notFoundID, customerIDs)
+	err := api.RemovePeopleFromSegment(context.Background(), notFoundID, "id", customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}


### PR DESCRIPTION
This PR introduces support for the `id_type` parameter in the `AddPeopleToSegment` and `RemovePeopleFromSegment` methods.

- The `id_type` parameter can now be optionally passed in the request.
- If `id_type` is not provided or an invalid value is passed, the default value (`id`) will be used.
- Validation of `id_type` is handled to ensure it defaults to a valid option when necessary.

### Changes:
- Updated `AddPeopleToSegment` and `RemovePeopleFromSegment` to accept and process `id_type`.
- Added tests to verify correct behavior of `id_type` handling.

This feature improves flexibility by allowing users to specify different types of customer identifiers (e.g., `email`, `cio_id`), while maintaining backward compatibility with the default `id` type.
