### PR TITLE
Add configurable options for CustomerIO to specify id_type

### DIFF
--- a/customerio.go
+++ b/customerio.go
@@ -22,6 +22,7 @@ type CustomerIO struct {
 	apiKey    string
 	URL       string
 	UserAgent string
+	IDType    string
 	Client    *http.Client
 }
 

--- a/options.go
+++ b/options.go
@@ -55,3 +55,12 @@ func WithUserAgent(ua string) option {
 		},
 	}
 }
+
+func WithIDType(idType string) option {
+	return option{
+		api: func(a *APIClient) {},
+		track: func(c *CustomerIO) {
+			c.IDType = idType
+		},
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -56,4 +56,10 @@ func TestTrackOptions(t *testing.T) {
 	if client.UserAgent != customUserAgent {
 		t.Errorf("wrong user-agent. got: %s, want: %s", client.UserAgent, customUserAgent)
 	}
+
+	emailIDType := "email"
+	client = customerio.NewTrackClient("site_id", "api_key", customerio.WithIDType(emailIDType))
+	if client.IDType != emailIDType {
+		t.Errorf("wrong id_type. got: %s, want: %s", client.IDType, emailIDType)
+	}
 }

--- a/segments_customerio.go
+++ b/segments_customerio.go
@@ -22,7 +22,7 @@ const (
 )
 
 // AddPeopleToSegment adds people to a segment.
-func (c *CustomerIO) AddPeopleToSegment(ctx context.Context, segmentID int, idType string, ids []string) error {
+func (c *CustomerIO) AddPeopleToSegment(ctx context.Context, segmentID int, ids []string) error {
 	if segmentID == 0 {
 		return ParamError{Param: "segmentID"}
 	}
@@ -30,14 +30,14 @@ func (c *CustomerIO) AddPeopleToSegment(ctx context.Context, segmentID int, idTy
 		return ParamError{Param: "ids"}
 	}
 	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/segments/%d/add_customers?id_type=%s", c.URL, segmentID, c.getValidIDType(idType)),
+		fmt.Sprintf("%s/api/v1/segments/%d/add_customers%s", c.URL, segmentID, c.getQueryParams()),
 		map[string]interface{}{
 			"ids": ids,
 		})
 }
 
 // RemovePeopleFromSegment removes people from a segment
-func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int, idType string, ids []string) error {
+func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int, ids []string) error {
 	if segmentID == 0 {
 		return ParamError{Param: "segmentID"}
 	}
@@ -45,18 +45,23 @@ func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int,
 		return ParamError{Param: "ids"}
 	}
 	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/segments/%d/remove_customers?id_type=%s", c.URL, segmentID, c.getValidIDType(idType)),
+		fmt.Sprintf("%s/api/v1/segments/%d/remove_customers%s", c.URL, segmentID, c.getQueryParams()),
 		map[string]interface{}{
 			"ids": ids,
 		})
 }
 
-// getValidIDType returns the valid IDType or defaults to IDTypeID
-func (c *CustomerIO) getValidIDType(idType string) IDType {
-	switch IDType(idType) {
+// getQueryParams returns the query parameter for the request.
+func (c *CustomerIO) getQueryParams() string {
+	if c.IDType == "" {
+		return ""
+	}
+
+	// Check if the IDType is valid and construct query parameter accordingly
+	switch IDType(c.IDType) {
 	case IDTypeEmail, IDTypeCioID:
-		return IDType(idType)
+		return fmt.Sprintf("?id_type=%s", c.IDType)
 	default:
-		return DefaultIDType
+		return fmt.Sprintf("?id_type=%s", DefaultIDType)
 	}
 }

--- a/segments_customerio_test.go
+++ b/segments_customerio_test.go
@@ -11,17 +11,15 @@ import (
 
 func TestAddPeopleToSegment(t *testing.T) {
 	customerIDs := []string{"1", "2", "3"}
-	var verify = func(req *http.Request) {
-		idType := req.URL.Query().Get("id_type")
-		if idType != "id" {
-			t.Errorf("Expected id_type to be 'id', got '%s'", idType)
-		}
-	}
+	var verify = func(req *http.Request) {}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), testSegmentID, "id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey")
+	api.URL = srv.URL
+
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, customerIDs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -36,10 +34,13 @@ func TestAddPeopleToSegmentEmailIDType(t *testing.T) {
 		}
 	}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), testSegmentID, "email", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey", customerio.WithIDType("email"))
+	api.URL = srv.URL
+
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, customerIDs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -54,10 +55,34 @@ func TestAddPeopleToSegmentCioIDType(t *testing.T) {
 		}
 	}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), testSegmentID, "cio_id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey", customerio.WithIDType("cio_id"))
+	api.URL = srv.URL
+
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, customerIDs)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAddPeopleToSegmentInvalidIDType(t *testing.T) {
+	customerIDs := []string{"1", "2", "3"}
+	var verify = func(req *http.Request) {
+		idType := req.URL.Query().Get("id_type")
+		if idType != "id" {
+			t.Errorf("Expected id_type to be 'id', got '%s'", idType)
+		}
+	}
+
+	srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	api := customerio.NewTrackClient("test", "myKey", customerio.WithIDType("invalid"))
+	api.URL = srv.URL
+
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, customerIDs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -67,10 +92,13 @@ func TestAddPeopleToSegmentSegmentParamError(t *testing.T) {
 	var customerIDs []string
 	var verify = func(req *http.Request) {}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), 0, "id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey")
+	api.URL = srv.URL
+
+	err := api.AddPeopleToSegment(context.Background(), 0, customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -84,10 +112,13 @@ func TestAddPeopleToSegmentIDsParamError(t *testing.T) {
 	var customerIDs []string
 	var verify = func(req *http.Request) {}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), testSegmentID, "id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey")
+	api.URL = srv.URL
+
+	err := api.AddPeopleToSegment(context.Background(), testSegmentID, customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -101,10 +132,13 @@ func TestAddPeopleToSegmentError(t *testing.T) {
 	customerIDs := []string{"1", "2", "3"}
 	var verify = func(req *http.Request) {}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.AddPeopleToSegment(context.Background(), notFoundID, "id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey")
+	api.URL = srv.URL
+
+	err := api.AddPeopleToSegment(context.Background(), notFoundID, customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -114,7 +148,7 @@ func TestAddPeopleToSegmentError(t *testing.T) {
 	}
 }
 
-func segmentsTrackServer(t *testing.T, verify func(req *http.Request)) (*customerio.CustomerIO, *httptest.Server) {
+func segmentsTrackServer(t *testing.T, verify func(req *http.Request)) *httptest.Server {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		verify(req)
 
@@ -132,25 +166,20 @@ func segmentsTrackServer(t *testing.T, verify func(req *http.Request)) (*custome
 		}
 	}))
 
-	api := customerio.NewCustomerIO("test", "myKey")
-	api.URL = srv.URL
-
-	return api, srv
+	return srv
 }
 
 func TestRemovePeopleFromSegment(t *testing.T) {
 	customerIDs := []string{"1", "2", "3"}
-	var verify = func(req *http.Request) {
-		idType := req.URL.Query().Get("id_type")
-		if idType != "id" {
-			t.Errorf("Expected id_type to be 'id', got '%s'", idType)
-		}
-	}
+	var verify = func(req *http.Request) {}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, "id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey")
+	api.URL = srv.URL
+
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, customerIDs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -165,10 +194,13 @@ func TestRemovePeopleToSegmentEmailIDType(t *testing.T) {
 		}
 	}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, "email", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey", customerio.WithIDType("email"))
+	api.URL = srv.URL
+
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, customerIDs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -183,10 +215,34 @@ func TestRemovePeopleToSegmentCioIDType(t *testing.T) {
 		}
 	}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, "cio_id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey", customerio.WithIDType("cio_id"))
+	api.URL = srv.URL
+
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, customerIDs)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestRemovePeopleToSegmentInvalidIDType(t *testing.T) {
+	customerIDs := []string{"1", "2", "3"}
+	var verify = func(req *http.Request) {
+		idType := req.URL.Query().Get("id_type")
+		if idType != "id" {
+			t.Errorf("Expected id_type to be 'id', got '%s'", idType)
+		}
+	}
+
+	srv := segmentsTrackServer(t, verify)
+	defer srv.Close()
+
+	api := customerio.NewTrackClient("test", "myKey", customerio.WithIDType("invalid"))
+	api.URL = srv.URL
+
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, customerIDs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -196,10 +252,13 @@ func TestRemovePeopleFromSegmentSegmentParamError(t *testing.T) {
 	var customerIDs []string
 	var verify = func(req *http.Request) {}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), 0, "id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey")
+	api.URL = srv.URL
+
+	err := api.RemovePeopleFromSegment(context.Background(), 0, customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -213,10 +272,13 @@ func TestRemovePeopleFromSegmentIDsParamError(t *testing.T) {
 	var customerIDs []string
 	var verify = func(req *http.Request) {}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, "id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey")
+	api.URL = srv.URL
+
+	err := api.RemovePeopleFromSegment(context.Background(), testSegmentID, customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}
@@ -230,10 +292,13 @@ func TestRemovePeopleFromSegmentError(t *testing.T) {
 	customerIDs := []string{"1", "2", "3"}
 	var verify = func(req *http.Request) {}
 
-	api, srv := segmentsTrackServer(t, verify)
+	srv := segmentsTrackServer(t, verify)
 	defer srv.Close()
 
-	err := api.RemovePeopleFromSegment(context.Background(), notFoundID, "id", customerIDs)
+	api := customerio.NewTrackClient("test", "myKey")
+	api.URL = srv.URL
+
+	err := api.RemovePeopleFromSegment(context.Background(), notFoundID, customerIDs)
 	if err == nil {
 		t.Errorf("Expected error, got: %#v", err)
 	}


### PR DESCRIPTION
This PR adds support for configuring `id_type` in the `CustomerIO` client based on Workspace Settings in Customer.io. Previously, the `id_type` defaulted to "id," but now users can specify the `id_type` ("id", "email", or "cio_id") depending on their workspace configuration.

**Changes**

- Made id_type configurable in the CustomerIO client to align with Customer.io Workspace Settings.
- Updated AddPeopleToSegment and RemovePeopleFromSegment methods to include the specified id_type in API requests.
- Ensured only valid id_type values are allowed, with "id" as the default when none is provided.