### PR TITLE
refactor(customerio): build URLs with net/url instead of fmt.Sprintf  [AMPB-826]

### DIFF
--- a/api.go
+++ b/api.go
@@ -32,7 +32,7 @@ func NewAPIClient(key string, opts ...option) *APIClient {
 	return client
 }
 
-func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, body interface{}) ([]byte, int, error) {
+func (c *APIClient) doRequest(ctx context.Context, verb string, body interface{}, segments ...string) ([]byte, int, error) {
 	var requestBody io.Reader
 
 	if body != nil {
@@ -43,7 +43,12 @@ func (c *APIClient) doRequest(ctx context.Context, verb, requestPath string, bod
 		requestBody = bytes.NewBuffer(b)
 	}
 
-	req, err := http.NewRequest(verb, c.URL+requestPath, requestBody)
+	u, err := buildURL(c.URL, nil, segments...)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	req, err := http.NewRequest(verb, u, requestBody)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/customerio.go
+++ b/customerio.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 )
@@ -78,9 +77,11 @@ func (c *CustomerIO) IdentifyCtx(ctx context.Context, customerID string, attribu
 	if customerID == "" {
 		return ParamError{Param: "customerID"}
 	}
-	return c.request(ctx, "PUT",
-		fmt.Sprintf("%s/api/v1/customers/%s", c.URL, url.PathEscape(customerID)),
-		attributes)
+	u, err := buildURL(c.URL, nil, "api", "v1", "customers", customerID)
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "PUT", u, attributes)
 }
 
 // Identify identifies a customer and sets their attributes
@@ -96,12 +97,14 @@ func (c *CustomerIO) TrackCtx(ctx context.Context, customerID string, eventName 
 	if eventName == "" {
 		return ParamError{Param: "eventName"}
 	}
-	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/customers/%s/events", c.URL, url.PathEscape(customerID)),
-		map[string]interface{}{
-			"name": eventName,
-			"data": data,
-		})
+	u, err := buildURL(c.URL, nil, "api", "v1", "customers", customerID, "events")
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "POST", u, map[string]interface{}{
+		"name": eventName,
+		"data": data,
+	})
 }
 
 // Track sends a single event to Customer.io for the supplied user
@@ -124,7 +127,11 @@ func (c *CustomerIO) TrackAnonymousCtx(ctx context.Context, anonymousID, eventNa
 		payload["anonymous_id"] = anonymousID
 	}
 
-	return c.request(ctx, "POST", fmt.Sprintf("%s/api/v1/events", c.URL), payload)
+	u, err := buildURL(c.URL, nil, "api", "v1", "events")
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "POST", u, payload)
 }
 
 // TrackAnonymous sends a single event to Customer.io for the anonymous user
@@ -137,9 +144,11 @@ func (c *CustomerIO) DeleteCtx(ctx context.Context, customerID string) error {
 	if customerID == "" {
 		return ParamError{Param: "customerID"}
 	}
-	return c.request(ctx, "DELETE",
-		fmt.Sprintf("%s/api/v1/customers/%s", c.URL, url.PathEscape(customerID)),
-		nil)
+	u, err := buildURL(c.URL, nil, "api", "v1", "customers", customerID)
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "DELETE", u, nil)
 }
 
 func (c *CustomerIO) auth() string {
@@ -237,12 +246,14 @@ func (c *CustomerIO) MergeCustomersCtx(ctx context.Context, primary Identifier, 
 		return ParamError{Param: "secondary"}
 	}
 
-	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/merge_customers", c.URL),
-		map[string]interface{}{
-			"primary":   primary.kv(),
-			"secondary": secondary.kv(),
-		})
+	u, err := buildURL(c.URL, nil, "api", "v1", "merge_customers")
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "POST", u, map[string]interface{}{
+		"primary":   primary.kv(),
+		"secondary": secondary.kv(),
+	})
 }
 
 // MergeCustomers sends a request to Customer.io to merge two customer profiles together.

--- a/device.go
+++ b/device.go
@@ -3,7 +3,6 @@ package customerio
 import (
 	"context"
 	"fmt"
-	"net/url"
 )
 
 type deviceV1 struct {
@@ -80,9 +79,11 @@ func (c *CustomerIO) AddDeviceCtx(ctx context.Context, customerID string, device
 		"device": d,
 	}
 
-	return c.request(ctx, "PUT",
-		fmt.Sprintf("%s/api/v1/customers/%s/devices", c.URL, url.PathEscape(customerID)),
-		body)
+	u, err := buildURL(c.URL, nil, "api", "v1", "customers", customerID, "devices")
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "PUT", u, body)
 }
 
 // AddDevice adds a device for a customer
@@ -98,9 +99,11 @@ func (c *CustomerIO) DeleteDeviceCtx(ctx context.Context, customerID string, dev
 	if deviceID == "" {
 		return ParamError{Param: "deviceID"}
 	}
-	return c.request(ctx, "DELETE",
-		fmt.Sprintf("%s/api/v1/customers/%s/devices/%s", c.URL, url.PathEscape(customerID), url.PathEscape(deviceID)),
-		nil)
+	u, err := buildURL(c.URL, nil, "api", "v1", "customers", customerID, "devices", deviceID)
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "DELETE", u, nil)
 }
 
 // DeleteDevice deletes a device for a customer

--- a/segments_api.go
+++ b/segments_api.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 )
 
 const errUnexpectedStatusCode = "unexpected status code %d"
@@ -61,7 +62,7 @@ type CreateSegmentResponse struct {
 
 // CreateSegment sends a request to create a new segment and returns the created segment data.
 func (c *APIClient) CreateSegment(ctx context.Context, req *CreateSegmentRequest) (*CreateSegmentResponse, error) {
-	body, statusCode, err := c.doRequest(ctx, "POST", "/v1/segments", req)
+	body, statusCode, err := c.doRequest(ctx, "POST", req, "v1", "segments")
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +84,7 @@ type ListSegmentsResponse struct {
 
 // ListSegments retrieves all segments from the API.
 func (c *APIClient) ListSegments(ctx context.Context) (*ListSegmentsResponse, error) {
-	respBody, statusCode, err := c.doRequest(ctx, "GET", "/v1/segments", nil)
+	respBody, statusCode, err := c.doRequest(ctx, "GET", nil, "v1", "segments")
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +106,7 @@ type GetSegmentResponse struct {
 
 // GetSegment retrieves a specific segment by its ID.
 func (c *APIClient) GetSegment(ctx context.Context, segmentID int) (*GetSegmentResponse, error) {
-	respBody, statusCode, err := c.doRequest(ctx, "GET", fmt.Sprintf("/v1/segments/%d", segmentID), nil)
+	respBody, statusCode, err := c.doRequest(ctx, "GET", nil, "v1", "segments", strconv.Itoa(segmentID))
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +123,7 @@ func (c *APIClient) GetSegment(ctx context.Context, segmentID int) (*GetSegmentR
 
 // DeleteSegment removes a segment by its ID.
 func (c *APIClient) DeleteSegment(ctx context.Context, segmentID int) error {
-	_, statusCode, err := c.doRequest(ctx, "DELETE", fmt.Sprintf("/v1/segments/%d", segmentID), nil)
+	_, statusCode, err := c.doRequest(ctx, "DELETE", nil, "v1", "segments", strconv.Itoa(segmentID))
 	if err != nil {
 		return err
 	}
@@ -143,7 +144,7 @@ type GetSegmentDependenciesResponse struct {
 
 // GetSegmentDependencies returns the dependencies of a specific segment.
 func (c *APIClient) GetSegmentDependencies(ctx context.Context, segmentID int) (*GetSegmentDependenciesResponse, error) {
-	respBody, statusCode, err := c.doRequest(ctx, "GET", fmt.Sprintf("/v1/segments/%d/used_by", segmentID), nil)
+	respBody, statusCode, err := c.doRequest(ctx, "GET", nil, "v1", "segments", strconv.Itoa(segmentID), "used_by")
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +166,7 @@ type GetSegmentCustomerCountResponse struct {
 
 // GetSegmentCustomerCount returns the total number of customers in a specific segment.
 func (c *APIClient) GetSegmentCustomerCount(ctx context.Context, segmentID int) (*GetSegmentCustomerCountResponse, error) {
-	respBody, statusCode, err := c.doRequest(ctx, "GET", fmt.Sprintf("/v1/segments/%d/customer_count", segmentID), nil)
+	respBody, statusCode, err := c.doRequest(ctx, "GET", nil, "v1", "segments", strconv.Itoa(segmentID), "customer_count")
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +197,7 @@ type CustomerIdentifier struct {
 
 // ListCustomersInSegment retrieves a list of customers in a specific segment.
 func (c *APIClient) ListCustomersInSegment(ctx context.Context, segmentID int) (*ListCustomersInSegmentResponse, error) {
-	respBody, statusCode, err := c.doRequest(ctx, "GET", fmt.Sprintf("/v1/segments/%d/membership", segmentID), nil)
+	respBody, statusCode, err := c.doRequest(ctx, "GET", nil, "v1", "segments", strconv.Itoa(segmentID), "membership")
 	if err != nil {
 		return nil, err
 	}

--- a/segments_customerio.go
+++ b/segments_customerio.go
@@ -2,7 +2,8 @@ package customerio
 
 import (
 	"context"
-	"fmt"
+	"net/url"
+	"strconv"
 )
 
 // IDType is the type of ids you want to use.
@@ -29,11 +30,13 @@ func (c *CustomerIO) AddPeopleToSegment(ctx context.Context, segmentID int, ids 
 	if len(ids) == 0 {
 		return ParamError{Param: "ids"}
 	}
-	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/segments/%d/add_customers%s", c.URL, segmentID, c.getQueryParams()),
-		map[string]interface{}{
-			"ids": ids,
-		})
+	u, err := buildURL(c.URL, c.idTypeQuery(), "api", "v1", "segments", strconv.Itoa(segmentID), "add_customers")
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "POST", u, map[string]interface{}{
+		"ids": ids,
+	})
 }
 
 // RemovePeopleFromSegment removes people from a segment
@@ -44,24 +47,29 @@ func (c *CustomerIO) RemovePeopleFromSegment(ctx context.Context, segmentID int,
 	if len(ids) == 0 {
 		return ParamError{Param: "ids"}
 	}
-	return c.request(ctx, "POST",
-		fmt.Sprintf("%s/api/v1/segments/%d/remove_customers%s", c.URL, segmentID, c.getQueryParams()),
-		map[string]interface{}{
-			"ids": ids,
-		})
+	u, err := buildURL(c.URL, c.idTypeQuery(), "api", "v1", "segments", strconv.Itoa(segmentID), "remove_customers")
+	if err != nil {
+		return err
+	}
+	return c.request(ctx, "POST", u, map[string]interface{}{
+		"ids": ids,
+	})
 }
 
-// getQueryParams returns the query parameter for the request.
-func (c *CustomerIO) getQueryParams() string {
+// idTypeQuery returns the id_type query parameter for segment requests, or nil
+// when no IDType is configured.
+func (c *CustomerIO) idTypeQuery() url.Values {
 	if c.IDType == "" {
-		return ""
+		return nil
 	}
 
-	// Check if the IDType is valid and construct query parameter accordingly
+	// Check if the IDType is valid and construct the query parameter accordingly.
+	v := url.Values{}
 	switch IDType(c.IDType) {
 	case IDTypeEmail, IDTypeCioID:
-		return fmt.Sprintf("?id_type=%s", c.IDType)
+		v.Set("id_type", c.IDType)
 	default:
-		return fmt.Sprintf("?id_type=%s", DefaultIDType)
+		v.Set("id_type", string(DefaultIDType))
 	}
+	return v
 }

--- a/transactional.go
+++ b/transactional.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"time"
 )
@@ -29,7 +28,7 @@ func (c *APIClient) sendTransactional(ctx context.Context, typ TransactionalType
 		return nil, ErrInvalidTransactionalMessageType
 	}
 
-	body, statusCode, err := c.doRequest(ctx, "POST", fmt.Sprintf("/v1/send/%s", api), req)
+	body, statusCode, err := c.doRequest(ctx, "POST", req, "v1", "send", api)
 	if err != nil {
 		return nil, err
 	}

--- a/url.go
+++ b/url.go
@@ -1,0 +1,33 @@
+package customerio
+
+import (
+	"net/url"
+	"strings"
+)
+
+// buildURL joins the given path segments onto base and appends the optional
+// query parameters, returning a fully-formed URL string. Each segment is
+// percent-escaped, so dynamic values (customer IDs, device IDs) can be passed
+// without pre-escaping; a "/" inside a segment is encoded as %2F rather than
+// being treated as a path separator.
+func buildURL(base string, query url.Values, segments ...string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+
+	rawPath := strings.TrimRight(u.EscapedPath(), "/")
+	path := strings.TrimRight(u.Path, "/")
+	for _, s := range segments {
+		rawPath += "/" + url.PathEscape(s)
+		path += "/" + s
+	}
+	u.Path = path
+	u.RawPath = rawPath
+
+	if len(query) > 0 {
+		u.RawQuery = query.Encode()
+	}
+
+	return u.String(), nil
+}

--- a/url_test.go
+++ b/url_test.go
@@ -1,0 +1,67 @@
+package customerio
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestBuildURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     string
+		query    url.Values
+		segments []string
+		want     string
+	}{
+		{
+			name:     "no query",
+			base:     "https://track.customer.io",
+			segments: []string{"api", "v1", "events"},
+			want:     "https://track.customer.io/api/v1/events",
+		},
+		{
+			name:     "base with trailing slash",
+			base:     "https://track.customer.io/",
+			segments: []string{"api", "v1", "events"},
+			want:     "https://track.customer.io/api/v1/events",
+		},
+		{
+			name:     "nil query produces no query string",
+			base:     "https://track.customer.io",
+			query:    nil,
+			segments: []string{"api", "v1", "segments", "42", "add_customers"},
+			want:     "https://track.customer.io/api/v1/segments/42/add_customers",
+		},
+		{
+			name:     "with query",
+			base:     "https://track.customer.io",
+			query:    url.Values{"id_type": {"email"}},
+			segments: []string{"api", "v1", "segments", "42", "add_customers"},
+			want:     "https://track.customer.io/api/v1/segments/42/add_customers?id_type=email",
+		},
+		{
+			name:     "dynamic segment with special characters is escaped",
+			base:     "https://track.customer.io",
+			segments: []string{"api", "v1", "customers", "john doe"},
+			want:     "https://track.customer.io/api/v1/customers/john%20doe",
+		},
+		{
+			name:     "slash inside a segment is encoded as %2F",
+			base:     "https://track.customer.io",
+			segments: []string{"api", "v1", "customers", "abc/def"},
+			want:     "https://track.customer.io/api/v1/customers/abc%2Fdef",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildURL(tt.base, tt.query, tt.segments...)
+			if err != nil {
+				t.Fatalf("buildURL() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("buildURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…[AMPB-826]

- Add buildURL helper (url.go) using net/url for structured URL construction
- Refactor track client URLs: customerio.go, device.go, segments_customerio.go
- Refactor API client URLs: api.go, segments_api.go, transactional.go
- Replace hand-built id_type query string (getQueryParams) with url.Values (idTypeQuery)
- doRequest now takes path segments instead of a pre-formatted path string
- Add unit tests for buildURL (url_test.go)

[AMPB-826]: https://captiv8.atlassian.net/browse/AMPB-826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ